### PR TITLE
fix old launch intent

### DIFF
--- a/app/src/main/java/org/eyeseetea/connect2connectexampleapp/SendExampleActivity.java
+++ b/app/src/main/java/org/eyeseetea/connect2connectexampleapp/SendExampleActivity.java
@@ -1,5 +1,6 @@
 package org.eyeseetea.connect2connectexampleapp;
 
+import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -50,14 +51,18 @@ public class SendExampleActivity extends AppCompatActivity {
 
     private void sendJsonText(String jsonToSend) {
         if (validateJson(jsonToSend)) {
-            Intent launchIntent = getPackageManager().getLaunchIntentForPackage(
-                    getString(R.string.connect_package));
-            if (launchIntent != null) {
-                Bundle mCredentialsBundle = new Bundle();
-                mCredentialsBundle.putString(CONNECT_VOUCHER, jsonToSend);
-                launchIntent.putExtras(mCredentialsBundle);
-                startActivity(launchIntent);
-            }
+            Intent launchIntent = new Intent();
+            Bundle mCredentialsBundle = new Bundle();
+            mCredentialsBundle.putString(CONNECT_VOUCHER, jsonToSend);
+            launchIntent.putExtras(mCredentialsBundle);
+            ComponentName componentName = new ComponentName(getString(R.string.connect_package), "org.eyeseetea.malariacare.SplashScreenActivity");
+            launchIntent.setComponent(componentName);
+            launchIntent.addCategory(Intent.ACTION_DEFAULT);
+            launchIntent.setAction(Intent.ACTION_SEND);
+            launchIntent.setType("text/plain");
+            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                    Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+            startActivity(launchIntent);
         }
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/pictureapp/issues/2254  
* **Required pull-requests:** https://github.com/EyeSeeTea/pictureapp/pull/2266

### :tophat: What is the goal?

Fix the problem when the second intent from connect to connect is not received on a device with lock system active in the ConnectToConnect side.

### :memo: How is it being implemented?

I added a flags to reset the active app and get the intent in the SplashScreenActivity.
I added a default category, send action, and plain text type to allow us to control better the intent.
And i replace the creation of the intent, adding the correct Component name instead of get the launch Intent from connect package.

### :boom: How can it be tested?

- [ ] **Use Case 1:** 

see the https://github.com/EyeSeeTea/pictureapp/pull/2266 Use case

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-


### Extra: Connect modifications

@ifoche Required Changes to make work the connectToConnect´s intent:

Replace sendJsonText method:

from:
```
    private void sendJsonText(String jsonToSend) {
        if (validateJson(jsonToSend)) {
            Intent launchIntent = getPackageManager().getLaunchIntentForPackage(
                    getString(R.string.connect_package));
            if (launchIntent != null) {
                Bundle mCredentialsBundle = new Bundle();
                mCredentialsBundle.putString(CONNECT_VOUCHER, jsonToSend);
                launchIntent.putExtras(mCredentialsBundle);
                startActivity(launchIntent);
            }
        }
    }
```

to

```
    private void sendJsonText(String jsonToSend) {
        if (validateJson(jsonToSend)) {
            Intent launchIntent = new Intent();
            Bundle mCredentialsBundle = new Bundle();
            mCredentialsBundle.putString(CONNECT_VOUCHER, jsonToSend);
            launchIntent.putExtras(mCredentialsBundle);
            ComponentName componentName = new ComponentName(getString(R.string.connect_package), "org.eyeseetea.malariacare.SplashScreenActivity");
            launchIntent.setComponent(componentName);
            launchIntent.addCategory(Intent.ACTION_DEFAULT);
            launchIntent.setAction(Intent.ACTION_SEND);
            launchIntent.setType("text/plain");
            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP |
                    Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
            startActivity(launchIntent);
        }
    }
```

